### PR TITLE
MultifilesLogger.jl

### DIFF
--- a/src/FileLogger.jl
+++ b/src/FileLogger.jl
@@ -14,8 +14,7 @@ struct FileLogger <: _iologger
     flush::Bool
     append::Bool
 
-    FileLogger(logPaths::Dict{LogLevel, String} = Dict(Info => "default.log"); flush = true, append = true) =
-        new(logPaths, Dict{LogLevel,IO}(), Dict{Any, Int}(), flush, append)
+    FileLogger(logPaths::Dict{LogLevel, String} = Dict(Info => "default.log"); flush = true, append = true) = new(logPaths, Dict{LogLevel,IO}(), Dict{Any, Int}(), flush, append)
 end
 
 CoreLogging.min_enabled_level(logger::FileLogger) = minimum(collect(keys(logger.logPaths)))

--- a/src/FileLogger.jl
+++ b/src/FileLogger.jl
@@ -14,7 +14,8 @@ struct FileLogger <: _iologger
     flush::Bool
     append::Bool
 
-    FileLogger(logPaths::Dict{LogLevel, String} = Dict(Info => "default.log"); flush = true, append = true) = new(logPaths, Dict{LogLevel,IO}(), Dict{Any, Int}(), flush, append)
+    FileLogger(logPaths::Dict{LogLevel, String} = Dict(Info => "default.log"); flush = true, append = true) =
+        new(logPaths, Dict{LogLevel,IO}(), Dict{Any, Int}(), flush, append)
 end
 
 CoreLogging.min_enabled_level(logger::FileLogger) = minimum(collect(keys(logger.logPaths)))

--- a/src/IOLogging.jl
+++ b/src/IOLogging.jl
@@ -4,7 +4,7 @@ using Base.CoreLogging
 using Base.CoreLogging: AbstractLogger, LogLevel, Debug, Info, Warn, Error, shouldlog, min_enabled_level, catch_exceptions, handle_message
 using Dates
 
-export IOLogger, FileLogger, MultifilesLogger
+export IOLogger, FileLogger, MultifilesLogger, FileDefForMultifilesLogger
 
 """
 Abstract supertype of all loggers contained in this package.

--- a/src/IOLogging.jl
+++ b/src/IOLogging.jl
@@ -4,7 +4,7 @@ using Base.CoreLogging
 using Base.CoreLogging: AbstractLogger, LogLevel, Debug, Info, Warn, Error, shouldlog, min_enabled_level, catch_exceptions, handle_message
 using Dates
 
-export IOLogger, FileLogger
+export IOLogger, FileLogger, MultifilesLogger
 
 """
 Abstract supertype of all loggers contained in this package.
@@ -109,5 +109,7 @@ function log!(io::T, level, message, _module, group, file, line; kwargs...) wher
 end
 
 include("FileLogger.jl")
+include("MultifilesLogger.jl")
+
 
 end # module

--- a/src/IOLogging.jl
+++ b/src/IOLogging.jl
@@ -83,6 +83,7 @@ CoreLogging.handle_message(logger::T,
 end
 
 function log!(io::T, level, message, _module, group, file, line; kwargs...) where { T <: IO }
+
     buffer = IOBuffer()
     context = IOContext(buffer, io)
     logTime = now()

--- a/src/MultifilesLogger.jl
+++ b/src/MultifilesLogger.jl
@@ -65,24 +65,18 @@ function getIOLevelTuple(logger::MultifilesLogger,
         # This stop condition is because 'parentmodule(Main) == Main'
         while parentmodule(_module) != _module
             _module = parentmodule(_module)
-            println("Check if the module[$(_module)] has a logger")
-
-            for k in collect(keys(logger.logIOs))
-                println("Is $(_module) == $(k): $(_module == k)")
-            end
 
             # If the parent module has a logger we use it
             if haskey(logger.logIOs,_module)
-                println("Found one!")
                 break
             end
         end
 
         # Throw an exception if no logger could be found for the parents
         if !haskey(logger.logIOs,_module)
-            throw(DomainError("There is no logger defined for [$(string(original_module))]"
-                            * " and we were unable to find a logger in the parents modules,"
-                            * " not event a logger for the 'Main' module."))
+            throw(DomainError("There is no logger defined for module[$(string(original_module))]"
+                            * " and we were also unable to find a logger in the parents modules,"
+                            * " not even a logger for the 'Main' module."))
         end
 
     end

--- a/src/MultifilesLogger.jl
+++ b/src/MultifilesLogger.jl
@@ -24,19 +24,6 @@ A multiple files logger for logging to files depending on the module.
 
 
 """
-
-struct FileDefForMultifilesLogger
-
-    filePath::String
-    append::Bool
-    modulesAndLogLevels::Vector{Tuple{Module,LogLevel}}
-
-    # FileDefForMultifilesLogger(filePath::String,
-    #                             append::Bool,
-    #                            vectorsAndLogLevels::Vector{Tuple{Module,LogLevel}}) =
-
-end
-
 struct MultifilesLogger <: _iologger
     filesDefs::Vector{FileDefForMultifilesLogger}
     logIOs::Dict{Module, Tuple{T,LogLevel}} where T <: IO
@@ -52,6 +39,14 @@ struct MultifilesLogger <: _iologger
                            createIOs!(x);
                            return x
                              )
+end
+
+struct FileDefForMultifilesLogger
+
+    filePath::String
+    append::Bool
+    modulesAndLogLevels::Vector{Tuple{Module,LogLevel}}
+
 end
 
 # CoreLogging.min_enabled_level(logger::MultifilesLogger) = minimum(collect(keys(logger.logPaths)))

--- a/src/MultifilesLogger.jl
+++ b/src/MultifilesLogger.jl
@@ -1,0 +1,126 @@
+"""
+A multiple files logger for logging to files depending on the module.
+Flushes the necessary output stream after each write (i.e. after each logging event) by default and closes the files on finalizing. Opened files are by default appended to. Given `append = false`, they will be overwritten.
+NOTE: Every module must be explicitely declared
+
+    MultifilesLogger(
+        logs_paths =  Dict("first.log" =>
+                                [(MyModule1.MySubModule1,Info),(MyModule1.MySubModule2,Info)],
+                            "second.log" => [(MyModule2,Info)],
+                            "Main.log" => [(Main,Info)]
+                            );
+        flush = true, append = true)
+
+Logs logging events with LogLevel greater than or equal to `Info` to "default.log", should no `logPaths` be given. In case two LogLevels are present, e.g. `Info` and `Error`, all logging events from `Info` up to (but excluding) `Error` will be logged to the file given by `Info`. `Error` and above will be logged to the file given by `Error`. It is possible to "clamp" logging events, by providing an upper bound that's logging to `/dev/null` on Unix/Mac or `NUL` on Windows. Beware, as the message will still be composed before writing to the actual file (no hotwiring).
+
+By default, exceptions occuring during logging are not caught. This is expected to change in the future, once it's decided how exceptions during logging should be handled.
+"""
+struct MultifilesLogger <: _iologger
+    logPaths::Dict{String, Vector{Tuple{Module,LogLevel}}}
+    logIOs::Dict{Module, Tuple{T,LogLevel}} where T <: IO
+    messageLimits::Dict{Any, Int}
+    flush::Bool
+    append::Bool
+
+    MultifilesLogger(
+        logPaths::Dict{String, Vector{Tuple{Module,LogLevel}}};
+        flush = true,
+        append = true) = (x = new(logPaths,
+                             Dict{Module, Tuple{IO,LogLevel}}(),
+                             Dict{Any, Int}(),
+                             flush,
+                             append);
+                           createIOs!(x);
+                           return x
+                             )
+end
+
+# CoreLogging.min_enabled_level(logger::MultifilesLogger) = minimum(collect(keys(logger.logPaths)))
+CoreLogging.min_enabled_level(logger::MultifilesLogger) = Info
+
+function createIOs!(logger::MultifilesLogger)
+
+    append_arg = logger.append
+    logs_paths = logger.logPaths
+
+    for (filepath,v) in logs_paths
+        # eg. (MyModule1.MySubModule1, Info)
+        for t in v
+            logger.logIOs[t[1]] =  (open(filepath,append_arg ? "a" : "w"),
+                                      t[2]
+                                      )
+        end
+
+    end
+
+end
+
+function getIOLevelTuple(logger::MultifilesLogger,
+                         _module::Module,
+                         Wlevel::LogLevel)
+
+    # If a module has no IO we try to find one
+    if !haskey(logger.logIOs,_module)
+        original_module = _module
+        # This stop condition is because 'parentmodule(Main) == Main'
+        while parentmodule(_module) != _module
+            _module = parentmodule(_module)
+            println("Check if the module[$(_module)] has a logger")
+
+            for k in collect(keys(logger.logIOs))
+                println("Is $(_module) == $(k): $(_module == k)")
+            end
+
+            # If the parent module has a logger we use it
+            if haskey(logger.logIOs,_module)
+                println("Found one!")
+                break
+            end
+        end
+
+        # Throw an exception if no logger could be found for the parents
+        if !haskey(logger.logIOs,_module)
+            throw(DomainError("There is no logger defined for [$(string(original_module))]"
+                            * " and we were unable to find a logger in the parents modules,"
+                            * " not event a logger for the 'Main' module."))
+        end
+
+    end
+
+    tuple_io_loglevel = logger.logIOs[_module]
+    return tuple_io_loglevel
+
+end
+
+
+CoreLogging.handle_message(logger::MultifilesLogger,
+                        level,
+                        message,
+                        _module,
+                        group,
+                        id,
+                        file,
+                        line;
+                        maxlog = nothing,
+                        kwargs...) = begin
+    # Should we log this?
+    if !checkLimits(logger, id, maxlog)
+        return
+    end
+
+
+    io_level_tuple = getIOLevelTuple(logger, _module, level)
+
+    io = io_level_tuple[1]
+    loglevel_limit = io_level_tuple[2]
+
+    # Check the the log level of the call is not below the limit
+    if level < loglevel_limit
+        return
+    end
+
+    log!(io, level, string(message), _module, group, file, line; kwargs...)
+
+    logger.flush ? flush(io) : nothing
+    nothing
+end

--- a/src/MultifilesLogger.jl
+++ b/src/MultifilesLogger.jl
@@ -17,18 +17,16 @@ end
 A multiple files logger for logging to files depending on the module.
 
     fileDef1 = FileDefForMultifilesLogger("first.log",
-                                          true, # append
                                           [(MyModule1.MySubModule1,Info),(MyModule1.MySubModule2,Info)],
                                           )
 
     fileDef2 = FileDefForMultifilesLogger("second.log",
-                                            true, # append
                                             [(MyModule2,Info)],
                                             )
 
     fileDef3 = FileDefForMultifilesLogger("main.log",
-                                            true, # append
-                                            [(Main,Info)],
+                                           [(Main,Info)];
+                                           append = false 
                                             )
 
     # Create the logger and set it as the global logger

--- a/src/MultifilesLogger.jl
+++ b/src/MultifilesLogger.jl
@@ -1,3 +1,9 @@
+struct FileDefForMultifilesLogger
+    filePath::String
+    append::Bool
+    modulesAndLogLevels::Vector{Tuple{Module,LogLevel}}
+end
+
 """
 A multiple files logger for logging to files depending on the module.
 
@@ -41,13 +47,7 @@ struct MultifilesLogger <: _iologger
                              )
 end
 
-struct FileDefForMultifilesLogger
 
-    filePath::String
-    append::Bool
-    modulesAndLogLevels::Vector{Tuple{Module,LogLevel}}
-
-end
 
 # CoreLogging.min_enabled_level(logger::MultifilesLogger) = minimum(collect(keys(logger.logPaths)))
 CoreLogging.min_enabled_level(logger::MultifilesLogger) = Info

--- a/test/runtests-MultifilesLogger.jl
+++ b/test/runtests-MultifilesLogger.jl
@@ -8,7 +8,6 @@ using Logging
 using Logging: Debug, Info, Warn, Error, BelowMinLevel, with_logger, min_enabled_level
 using Test
 
-
 # TODO make some real tests sets
 
 # Declare

--- a/test/runtests-MultifilesLogger.jl
+++ b/test/runtests-MultifilesLogger.jl
@@ -1,0 +1,56 @@
+using Pkg
+Pkg.activate(".")
+
+using Revise
+
+using IOLogging
+using Logging
+using Logging: Debug, Info, Warn, Error, BelowMinLevel, with_logger, min_enabled_level
+using Test
+
+
+# TODO make some real tests sets
+
+# Declare
+module MyModule1
+    module MySubModule1
+        sayhello() = @info "MyModule1.MySubModule1 sayhello"
+
+        module MySubSubModule1
+        end
+    end
+    module MySubModule2
+        sayhello() = @info "MyModule1.MySubModule2 sayhello"
+    end
+end
+
+module MyModule2
+    module MySubModule1
+        sayhello() = @info "MyModule2.MySubModule1 sayhello"
+    end
+    module MySubModule2
+        sayhello() = @info "MyModule2.MySubModule2 sayhello"
+    end
+end
+
+parentmodule(MyModule1.MySubModule1.MySubSubModule1)
+parentmodule(MyModule1)
+
+MyModule1.MySubModule1.sayhello()
+
+# Prepare the configuration
+#
+logs_paths =  Dict("first.log" =>
+                        [(MyModule1.MySubModule1,Info),(MyModule1.MySubModule2,Info)],
+                    "second.log" => [(MyModule2,Info)],
+                    "Main.log" => [(Main,Info)]
+                    )
+
+multifilesLogger = MultifilesLogger(
+    logs_paths;flush = true, append = true)
+
+
+global_logger(multifilesLogger)
+
+MyModule1.MySubModule1.sayhello()
+MyModule2.MySubModule1.sayhello()

--- a/test/runtests-MultifilesLogger.jl
+++ b/test/runtests-MultifilesLogger.jl
@@ -34,17 +34,26 @@ module MyModule2
 end
 
 #
-# Prepare the configuration
+# Configure the log files
 #
-logs_paths =  Dict("first.log" =>
-                        [(MyModule1.MySubModule1,Info),(MyModule1.MySubModule2,Info)],
-                    "second.log" => [(MyModule2,Info)],
-                    "Main.log" => [(Main,Info)]
-                    )
+fileDef1 = FileDefForMultifilesLogger("first.log",
+                                      true, # append
+                                      [(MyModule1.MySubModule1,Info),(MyModule1.MySubModule2,Info)],
+                                      )
+
+fileDef2 = FileDefForMultifilesLogger("second.log",
+                                        true, # append
+                                        [(MyModule2,Info)],
+                                        )
+
+fileDef3 = FileDefForMultifilesLogger("main.log",
+                                        true, # append
+                                        [(Main,Info)],
+                                        )
 
 # Create the logger and set it as the global logger
-multifilesLogger = MultifilesLogger(
-    logs_paths;flush = true, append = true)
+multifilesLogger =
+    MultifilesLogger([fileDef1,fileDef2,fileDef3])
 
 global_logger(multifilesLogger)
 
@@ -61,15 +70,10 @@ MyModule2.MySubModule1.sayhello()
 # mktempdir(@__DIR__) do dir
 #     cd(dir) do
 #         @testset "Assertions" begin
-#             logs_paths =  Dict("first.log" =>
-#                                     [(MyModule1.MySubModule1,Info),(MyModule1.MySubModule2,Info)],
-#                                 "second.log" => [(MyModule2,Info)],
-#                                 "Main.log" => [(Main,Info)]
-#                                 )
-#
+#             #
 #             # Create the logger and set it as the global logger
-#             multifilesLogger = MultifilesLogger(
-#                 logs_paths;flush = true, append = false)
+#             multifilesLogger =
+#                 MultifilesLogger([fileDef1,fileDef2,fileDef3])
 #
 #             global_logger(multifilesLogger)
 #

--- a/test/runtests-MultifilesLogger.jl
+++ b/test/runtests-MultifilesLogger.jl
@@ -30,22 +30,25 @@ module MyModule2
     end
 end
 
+module MyModule3
+    sayhello() = @info "MyModule3 sayhello"
+end
+
 #
 # Configure the log files
 #
 fileDef1 = FileDefForMultifilesLogger("first.log",
-                                      true, # append
-                                      [(MyModule1.MySubModule1,Info),(MyModule1.MySubModule2,Info)],
+                                      [(MyModule1.MySubModule1,Info),
+                                       (MyModule1.MySubModule2,Info)],
                                       )
 
 fileDef2 = FileDefForMultifilesLogger("second.log",
-                                        true, # append
                                         [(MyModule2,Info)],
                                         )
 
 fileDef3 = FileDefForMultifilesLogger("main.log",
-                                        true, # append
-                                        [(Main,Info)],
+                                        [(Main,Info)];
+                                        append = false
                                         )
 
 # Create the logger and set it as the global logger
@@ -53,7 +56,6 @@ multifilesLogger =
     MultifilesLogger([fileDef1,fileDef2,fileDef3])
 
 global_logger(multifilesLogger)
-
 
 # First test with a module that is explicitely associated to a log file
 MyModule1.MySubModule1.sayhello()
@@ -64,3 +66,12 @@ MyModule2.MySubModule1.sayhello()
 
 # Test the logging for the 'Main' module
 @info "Should appear in main.log"
+
+# Test what happens when there is no IO on the Main module and that a module
+#   is missing its IO
+multifilesLogger =
+    MultifilesLogger([fileDef1,fileDef2])
+
+global_logger(multifilesLogger)
+
+MyModule3.sayhello()

--- a/test/runtests-MultifilesLogger.jl
+++ b/test/runtests-MultifilesLogger.jl
@@ -33,11 +33,7 @@ module MyModule2
     end
 end
 
-parentmodule(MyModule1.MySubModule1.MySubSubModule1)
-parentmodule(MyModule1)
-
-MyModule1.MySubModule1.sayhello()
-
+#
 # Prepare the configuration
 #
 logs_paths =  Dict("first.log" =>
@@ -46,11 +42,53 @@ logs_paths =  Dict("first.log" =>
                     "Main.log" => [(Main,Info)]
                     )
 
+# Create the logger and set it as the global logger
 multifilesLogger = MultifilesLogger(
     logs_paths;flush = true, append = true)
 
-
 global_logger(multifilesLogger)
 
+
+# First test with a module that is explicitely associated to a log file
 MyModule1.MySubModule1.sayhello()
+
+# Test the fallback mechanism when the module is not associated to a log file
+#  but one of its ancestors is.
 MyModule2.MySubModule1.sayhello()
+
+
+# Failed attempt to create some unit tests
+# mktempdir(@__DIR__) do dir
+#     cd(dir) do
+#         @testset "Assertions" begin
+#             logs_paths =  Dict("first.log" =>
+#                                     [(MyModule1.MySubModule1,Info),(MyModule1.MySubModule2,Info)],
+#                                 "second.log" => [(MyModule2,Info)],
+#                                 "Main.log" => [(Main,Info)]
+#                                 )
+#
+#             # Create the logger and set it as the global logger
+#             multifilesLogger = MultifilesLogger(
+#                 logs_paths;flush = true, append = false)
+#
+#             global_logger(multifilesLogger)
+#
+#             # Let the time to create the log files
+#             sleep(2)
+#
+#             # First test with a module that is explicitely associated to a log file
+#             MyModule1.MySubModule1.sayhello()
+#
+#             # Test the fallback mechanism when the module is not associated to a log file
+#             #  but one of its ancestors is.
+#             MyModule2.MySubModule1.sayhello()
+#
+#             # Let the time to go check the content of the log files
+#             sleep(15)
+#
+#             lines = readlines("first.log", keep = true)
+#             # println(lines[1])
+#             # @test occursin("MyModule1.MySubModule1 sayhello", lines[1])
+#         end
+#     end
+# end

--- a/test/runtests-MultifilesLogger.jl
+++ b/test/runtests-MultifilesLogger.jl
@@ -1,8 +1,6 @@
 using Pkg
 Pkg.activate(".")
 
-using Revise
-
 using IOLogging
 using Logging
 using Logging: Debug, Info, Warn, Error, BelowMinLevel, with_logger, min_enabled_level
@@ -66,34 +64,3 @@ MyModule2.MySubModule1.sayhello()
 
 # Test the logging for the 'Main' module
 @info "Should appear in main.log"
-
-# Failed attempt to create some unit tests
-# mktempdir(@__DIR__) do dir
-#     cd(dir) do
-#         @testset "Assertions" begin
-#             #
-#             # Create the logger and set it as the global logger
-#             multifilesLogger =
-#                 MultifilesLogger([fileDef1,fileDef2,fileDef3])
-#
-#             global_logger(multifilesLogger)
-#
-#             # Let the time to create the log files
-#             sleep(2)
-#
-#             # First test with a module that is explicitely associated to a log file
-#             MyModule1.MySubModule1.sayhello()
-#
-#             # Test the fallback mechanism when the module is not associated to a log file
-#             #  but one of its ancestors is.
-#             MyModule2.MySubModule1.sayhello()
-#
-#             # Let the time to go check the content of the log files
-#             sleep(15)
-#
-#             lines = readlines("first.log", keep = true)
-#             # println(lines[1])
-#             # @test occursin("MyModule1.MySubModule1 sayhello", lines[1])
-#         end
-#     end
-# end

--- a/test/runtests-MultifilesLogger.jl
+++ b/test/runtests-MultifilesLogger.jl
@@ -65,6 +65,8 @@ MyModule1.MySubModule1.sayhello()
 #  but one of its ancestors is.
 MyModule2.MySubModule1.sayhello()
 
+# Test the logging for the 'Main' module
+@info "Should appear in main.log"
 
 # Failed attempt to create some unit tests
 # mktempdir(@__DIR__) do dir


### PR DESCRIPTION
`MultifilesLogger` allows to have several log files.
Every log file is associated to a vector of Tuple{Module, LogLevel} using the struct `FileDefForMultifilesLogger`.

If a module is not associated to an IO, `getIOLevelTuple!()` will try to associate the module with the IO of a parent module.

NOTE: `test/runtests-MultifilesLogger.jl` would require some properly written tests. My first attempt to mimic the test sets of FileLogger has failed (the log files are empty, I don't understand why). 